### PR TITLE
feat: add support for ephemeral containers

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "0.6.3"
+const version = "0.6.4"
 
 var rootCmd *cobra.Command
 

--- a/kubectl_images.go
+++ b/kubectl_images.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	podTemplate  = `go-template={{range .items}} {{.metadata.namespace}} {{","}} {{.metadata.name}} {{","}} {{range .spec.containers}} {{.name}} {{","}} {{.image}} {{","}} {{.imagePullPolicy}} {{"\n"}} {{end}} {{range .spec.initContainers}} {{"(init)"}} {{.name}} {{","}} {{.image}} {{","}} {{.imagePullPolicy}} {{"\n"}} {{end}} {{end}}`
+	podTemplate  = `go-template={{range .items}} {{.metadata.namespace}} {{","}} {{.metadata.name}} {{","}} {{range .spec.containers}} {{.name}} {{","}} {{.image}} {{","}} {{.imagePullPolicy}} {{"\n"}} {{end}} {{range .spec.initContainers}} {{"(init)"}} {{.name}} {{","}} {{.image}} {{","}} {{.imagePullPolicy}} {{"\n"}} {{end}} {{range .spec.ephemeralContainers}} {{"(ephemeral)"}} {{.name}} {{","}} {{.image}} {{","}} {{.imagePullPolicy}} {{"\n"}} {{end}} {{end}}`
 	nodeTemplate = `go-template={{range .items}} {{range .status.images}} {{range .names}} {{.}} {{","}} {{end}} {{.sizeBytes}} {{"\n"}} {{end}} {{end}}`
 
 	labelNamespace       = "Namespace"


### PR DESCRIPTION
## Summary
- Add support for ephemeral containers in addition to regular containers and init containers
- Ephemeral containers are labeled with "(ephemeral)" prefix to distinguish them
- Bump version to 0.6.4

Fixes #27

## Test plan
- [ ] Run `kubectl images` against a cluster with ephemeral containers
- [ ] Verify ephemeral containers appear with "(ephemeral)" prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)