### PR TITLE
docs: clarify flag precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Examples:
   kubectl images -n dev nginx -c 1,2
 
 Flags:
-  -A, --all-namespaces         if present, list images in all namespaces.
+  -A, --all-namespaces         if present, list images in all namespaces. Overrides -n/--namespace.
   -c, --columns string         specify the columns to display, separated by comma. [0:Namespace, 1:PodName, 2:ContainerName, 3:ContainerImage, 4:ImagePullPolicy, 5:ImageSize] (default "1,2,3")
   -C, --context string         The name of the kubeconfig context to use.
   -h, --help                   help for kubectl-images

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -53,7 +53,7 @@ func init() {
 			kubeImage.Render(format)
 		},
 	}
-	rootCmd.Flags().BoolP("all-namespaces", "A", false, "if present, list images in all namespaces.")
+	rootCmd.Flags().BoolP("all-namespaces", "A", false, "if present, list images in all namespaces. Overrides -n/--namespace.")
 	rootCmd.Flags().StringP("namespace", "n", "", "if present, list images in the specified namespace only. Use current namespace as fallback.")
 	rootCmd.Flags().StringP("columns", "c", "1,2,3", "specify the columns to display, separated by comma. [0:Namespace, 1:PodName, 2:ContainerName, 3:ContainerImage, 4:ImagePullPolicy, 5:ImageSize]")
 	rootCmd.Flags().StringP("kubeconfig", "k", "", "path to the kubeconfig file to use for CLI requests.")


### PR DESCRIPTION
## Summary

I noticed that current help message doesn't clarify what happens with both `-n/--namespace` and `-A/--all-namespaces` flags set. The precedence is determined in [kubectl_images.go:#174-178](https://github.com/chenjiandongx/kubectl-images/blob/62d58004d658c9620b67a8398982c45edbbe72b1/kubectl_images.go#L174-L178), where `-A` takes precedence over `-n`. Since both flags can be specified together, documenting their precedence makes the behavior explicit, as the namespace column is not shown by default.

## Changes

This change clarifies that in [cmd/main.go#56](https://github.com/chenjiandongx/kubectl-images/blob/62d58004d658c9620b67a8398982c45edbbe72b1/cmd/main.go#L56) and correspondingly [README.md#163](https://github.com/chenjiandongx/kubectl-images/blob/62d58004d658c9620b67a8398982c45edbbe72b1/README.md?plain=1#L63), stating that `-A` overrides `-n`.